### PR TITLE
Prepare v0.1.1

### DIFF
--- a/src/Fornax.Seo/Core.fs
+++ b/src/Fornax.Seo/Core.fs
@@ -140,7 +140,7 @@ module Core =
                                          Port = -1
                                      ).Uri.AbsoluteUri
                                  else
-                                     (sprintf "%s%s%s" Uri.UriSchemeHttps Uri.SchemeDelimiter uri.OriginalString)
+                                     $"{Uri.UriSchemeHttps}{Uri.SchemeDelimiter}{uri.OriginalString}"
                                          .Replace("///", "//")
 
                              (siteLink, link, Map.tryFind link mediaIcons |> Option.defaultValue "fa-external-link")
@@ -160,10 +160,10 @@ module Core =
                         (if String.IsNullOrEmpty(siteAuthor) then
                              String.Empty
                          else
-                             sprintf "Find %s on %s" siteAuthor siteName)
+                             $"Find {siteAuthor} on {siteName}")
 
                     a [ Href link; HtmlProperties.Title linkTitle; Class "navicon" ] [
-                        i [ Class((sprintf "media-icon fa %s" icon)); Custom("aria-hidden", "true") ] []
+                        i [ Class(($"media-icon fa {icon}")); Custom("aria-hidden", "true") ] []
                     ])
             )
 

--- a/src/Fornax.Seo/Fornax.Seo.fsproj
+++ b/src/Fornax.Seo/Fornax.Seo.fsproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk" InitialTargets="ToolRestore">
   <PropertyGroup>
-    <VersionPrefix>0.1.0</VersionPrefix>
+    <VersionPrefix>0.1.1</VersionPrefix>
+    <VersionSuffix>rc-1</VersionSuffix>
     <Authors>Robert Di Pardo</Authors>
     <Copyright>Copyright (c) 2021 Robert Di Pardo and Contributors</Copyright>
     <Description>A SEO meta tag generator for Fornax (https://ionide.io/Tools/fornax.html)</Description>
@@ -18,6 +19,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Models.fs"/>
+    <Compile Include="StructuredData.fs"/>
     <Compile Include="Tags.fs"/>
     <Compile Include="Core.fs"/>
   </ItemGroup>

--- a/src/Fornax.Seo/Models.fs
+++ b/src/Fornax.Seo/Models.fs
@@ -14,9 +14,9 @@ module Models =
     open FSharp.Data
 
     [<Literal>]
-    let private schemaDotOrg = @"https://schema.org/version/latest/schemaorg-current-https.jsonld"
+    let private SchemaDotOrg = @"https://schema.org/version/latest/schemaorg-current-https.jsonld"
 
-    type internal SchemaProvider = JsonProvider<schemaDotOrg>
+    type internal SchemaProvider = JsonProvider<SchemaDotOrg>
 
     /// Represents the author of a web content item
     type ContentCreator =

--- a/src/Fornax.Seo/StructuredData.fs
+++ b/src/Fornax.Seo/StructuredData.fs
@@ -1,0 +1,59 @@
+//
+// Copyright (c) 2021 Robert Di Pardo and Contributors
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+
+namespace Fornax.Seo
+
+/// Internal representations of SEO metadata objects
+/// <exclude />
+module StructuredData =
+    open Html
+    open Newtonsoft.Json
+
+    [<Struct>]
+    type SchemaDotOrgContext =
+        val Rdf: string
+        val Rdfs: string
+        val Schema: string
+        val Xsd: string
+        new(cxt: SchemaProvider.Context) = { Rdf = cxt.Rdf; Rdfs = cxt.Rdfs; Schema = cxt.Schema; Xsd = cxt.Xsd }
+
+    [<Struct>]
+    type MainEntity =
+        { [<JsonProperty("@type")>]
+          Schema: string
+          [<JsonProperty("@id")>]
+          Id: string }
+
+    [<Struct>]
+    type Author =
+        { [<JsonProperty("@type")>]
+          Schema: string
+          Name: string
+          [<JsonProperty("sameAs")>]
+          Links: string list }
+
+    type OpenGraphArticle =
+        { Published_time: string
+          Modified_time: string
+          Author: string
+          Tags: string list option }
+
+        member this.ToHtml() =
+            let tags =
+                defaultArg this.Tags []
+                |> List.map (fun t -> meta [ Property "article:tag"; Content t ])
+
+            this.GetType().GetProperties()
+            |> Array.filter
+                (fun prop ->
+                    not <| obj.ReferenceEquals(prop.GetValue(this, null), null)
+                    && not <| obj.ReferenceEquals(prop.GetValue(this, null), None)
+                    && prop.Name <> "Tags")
+            |> Array.map (fun prop -> "article:" + prop.Name.ToLowerInvariant(), prop.GetValue(this, null).ToString())
+            |> (Map.ofArray
+                >> Map.fold (fun lst p c -> lst @ [ meta [ Property p; Content c ] ]) tags)

--- a/test/Fornax.Seo.Tests/UnitTests.fs
+++ b/test/Fornax.Seo.Tests/UnitTests.fs
@@ -65,6 +65,15 @@ module UnitTests =
             | None -> Assert.Fail($"Expected to find {expected}")
 
         [<Test>]
+        member x.``Metadata includes Fornax version``() =
+            let expected = $"""<meta name="generator" content="fornax v0.13.1"/>"""
+
+            x.TryFindSeoTag(expected)
+            |> function
+            | Some _ -> Assert.Pass()
+            | None -> Assert.Fail($"Expected to find {expected}")
+
+        [<Test>]
         member x.``Social media links are styled when present``() =
             let expected = ".media-icon"
 
@@ -178,16 +187,23 @@ module UnitTests =
             Assert.Null(json.MainEntityOfPage.Id)
 
         [<Test>]
-        member x.``Validates mainEntity's Schema.org Type``() =
+        member x.``Validates ContentObject's Schema.org Type``() =
             let f =
                 TestDelegate(fun () -> seo ({ pageInfo with ObjectType = Some "Starbucks" }) |> ignore)
 
             Assert.Throws<System.ArgumentException>(f) |> ignore
 
         [<Test>]
-        member x.``Validates page content's Schema.org Type``() =
+        member x.``Validates MainEntity's Schema.org Type``() =
             let f =
                 TestDelegate(fun () -> seo ({ pageInfo with ContentType = Some "dog.food" }) |> ignore)
+
+            Assert.Throws<System.ArgumentException>(f) |> ignore
+
+        [<Test>]
+        member x.``Validates ContentObject's OpenGraphType Type``() =
+            let f =
+                TestDelegate(fun () -> seo ({ pageInfo with OpenGraphType = Some "" }) |> ignore)
 
             Assert.Throws<System.ArgumentException>(f) |> ignore
 


### PR DESCRIPTION
* _Provide a clear and concise description of what your pull request fixes or adds_

An empty string is not a valid OpenGraph type, but the lambda that should be checking for this returns `true` _precisely_ when the input is an empty string :information_source:

https://github.com/rdipardo/Fornax.Seo/blob/1a619ba84ba0966f04bb5b9f893cf7fb21847e56/src/Fornax.Seo/Tags.fs#L88

Not only is `StartsWith()` a defective comparison, but the wrong variable is being normalized &#x2013; the list items are already hard-coded in lowercase!

I've made the validation more and less rigorous at the same time.
Input must now be non-empty and contain every character as a matching item, but you can mix in capitals letters and still get a match.

Also:
  * moved `StructuredData` to its own file and declared some smaller records as value types
  * cleaned up the syntactic mess of applyig `sprintf` to the results of insance methods, and the backward pipes that necessitates

----
:information_source:
> To be equal, `value` must be an empty string ([`String.Empty`][]), must be a reference to this same instance, or must match the beginning of this instance.

[System.String.StartsWith(String)](https://docs.microsoft.com/en-us/dotnet/api/system.string.startswith?view=net-5.0#system-string-startswith(system-string))

[`String.Empty`]: https://docs.microsoft.com/en-us/dotnet/api/system.string.empty?view=net-5.0
